### PR TITLE
ESM Support

### DIFF
--- a/package.esm.json
+++ b/package.esm.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "main": "lib/index.js",
   "exports": {
     "require": "./lib/index.js",
-    "import": "./lib/esm/index.js"
+    "import": "./lib/esm/index.js",
+    "default": "./lib/esm/index.js"
   },
   "type": "commonjs",
+  "module": "lib/esm/index.js",
+  "jsnext:main": "lib/esm/index.js",
   "typings": "lib/index.d.ts",
   "engines": {
     "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -3,12 +3,17 @@
   "version": "0.0.0-development",
   "description": "Error-making utility for JavaScript apps.",
   "main": "lib/index.js",
+  "exports": {
+    "require": "./lib/index.js",
+    "import": "./lib/esm/index.js"
+  },
+  "type": "commonjs",
   "typings": "lib/index.d.ts",
   "engines": {
     "node": ">=6.0.0"
   },
   "scripts": {
-    "build": "rimraf lib && tsc -p tsconfig.build.json",
+    "build": "rimraf lib && tsc -p tsconfig.build.cjs.json && tsc -p tsconfig.build.esm.json && cp package.esm.json lib/esm/package.json",
     "test": "jest",
     "test:watch": "jest --watchAll",
     "check": "tsc -p tsconfig.json --noEmit --pretty",

--- a/src/make-error-class.ts
+++ b/src/make-error-class.ts
@@ -1,6 +1,8 @@
-import { BaseError as CustomError } from 'make-error'
+import MakeError from 'make-error'
 import { retry, RetryOptions } from './retry'
 import { ignore, IgnoreFunc } from './ignore'
+
+const CustomError = MakeError.BaseError
 
 /**
  * Base error class.

--- a/tsconfig.build.cjs.json
+++ b/tsconfig.build.cjs.json
@@ -4,5 +4,8 @@
     "__tests__",
     "**/__tests__/*",
     "node_modules/*"
-  ]
+  ],
+  "compilerOptions": {
+    "outDir": "./lib"
+  }
 }

--- a/tsconfig.build.esm.json
+++ b/tsconfig.build.esm.json
@@ -9,6 +9,6 @@
     "outDir": "./lib/esm",
     "target": "es2015",
     "module": "es2015",
-    "sourceMap": false,
+    "sourceMap": true
   }
 }

--- a/tsconfig.build.esm.json
+++ b/tsconfig.build.esm.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "__tests__",
+    "**/__tests__/*",
+    "node_modules/*"
+  ],
+  "compilerOptions": {
+    "outDir": "./lib/esm",
+    "target": "es2015",
+    "module": "es2015",
+    "sourceMap": false,
+  }
+}


### PR DESCRIPTION
This pull request works by transpiling to CJS and ESM seperately and then using [Conditional Exports](https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_conditional_exports) to appropriately switch between ESM and CJS depending on whether the user is using either. 

The `package.json` added to the esm folder in lib was the only way I found to tell Node that the files were ESM rather than CJS.

The change in `make-error-class` was necessary due to the `make-error` lib not supporting ESM.